### PR TITLE
Add option to invert role selection for trigger.

### DIFF
--- a/lang/en/lifecycletrigger_byrole.php
+++ b/lang/en/lifecycletrigger_byrole.php
@@ -23,6 +23,8 @@
 $string['pluginname'] = 'Delete courses by roles missing';
 $string['delay'] = 'Days of delay for triggering';
 $string['delay_help'] = 'Days a course has to remain without any responsible person until the course is finally triggered';
+$string['invert'] = 'Invert role selection for triggering.';
+$string['invert_help'] = 'If ticked, any of the selected roles have to be present for a course to be triggered.';
 $string['responsibleroles'] = 'Responsible Roles in courses';
 $string['responsibleroles_help'] = 'Select the roles that have to be presented within a course. If one of the roles is present the course is not triggered.';
 $string['privacy:metadata'] = 'Does not store user specific data';

--- a/lib.php
+++ b/lib.php
@@ -100,9 +100,11 @@ class byrole extends base_automatic {
 
         list($insql, $inparams) = $DB->get_in_or_equal($this->get_roles($triggerid), SQL_PARAMS_NAMED);
 
+        $invert = settings_manager::get_settings($triggerid, settings_type::TRIGGER)['invert'] && true;
+
         $sql = "SELECT c.id
             FROM {course} c
-            WHERE c.id NOT IN (
+            WHERE c.id " . ($invert ? "" : "NOT") . " IN (
             SELECT e.courseid FROM {context} coursectx
               JOIN {enrol} e ON coursectx.contextlevel = 50 AND e.courseid = coursectx.instanceid AND e.status = 0
               JOIN {user_enrolments} ue ON e.id = ue.enrolid AND ue.status = 0
@@ -159,6 +161,7 @@ class byrole extends base_automatic {
     public function instance_settings() {
         return array(
             new instance_setting('roles', PARAM_SEQUENCE),
+            new instance_setting('invert', PARAM_BOOL),
             new instance_setting('delay', PARAM_INT),
         );
     }
@@ -187,6 +190,9 @@ class byrole extends base_automatic {
         $mform->addHelpButton('roles', 'responsibleroles', 'lifecycletrigger_byrole');
         $mform->setType('roles', PARAM_SEQUENCE);
         $mform->addRule('roles', 'Test', 'required');
+
+        $mform->addElement('advcheckbox', 'invert', get_string('invert', 'lifecycletrigger_byrole'), get_string('invert_help', 'lifecycletrigger_byrole'));
+        $mform->setType('invert', PARAM_BOOL);
 
         $elementname = 'delay';
         $mform->addElement('duration', $elementname, get_string('delay', 'lifecycletrigger_byrole'));


### PR DESCRIPTION
As `lifecycletrigger_byrole` has a handy delay function to delay setting the trigger off, we wanted to use it with a "watchdog" role like "Authenticated User" which is not present in any course ever. Unfortunately, this would not be limited to any courses outside our desired category (set up in a parallel trigger), as each trigger works independently of others. The delay would then begin upon activation of the workflow...

We liked the idea of a watchdog role, however. We created a category enrolment for that role within our "trash" category and added the option to invert the role selection for this trigger. In this way this trigger can be used as:

- a simple delay trigger
- a category trigger
- a manual trigger (if teachers are allowed to assign this role, possibly to themselves)